### PR TITLE
Add option for outputing inclusion proof in JSON. HRST-24.

### DIFF
--- a/serverless/cmd/client/client.go
+++ b/serverless/cmd/client/client.go
@@ -358,6 +358,7 @@ func (l *logClientTool) inclusionProof(ctx context.Context, args []string) error
 
                 if err := os.WriteFile(oj, ps, 0644); err != nil {
 			glog.Warningf("Failed to write JSON inclusion proof to %q: %v", oj, err)
+			return err
                 }
         }
 

--- a/serverless/cmd/client/client.go
+++ b/serverless/cmd/client/client.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+        "encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -79,6 +80,7 @@ var (
 	outputConsistency   = flag.String("output_consistency_proof", "", "If set, the update and consistency commands will write the verified consistency proof used to update the checkpoint to this file")
 	outputInclusion     = flag.String("output_inclusion_proof", "", "If set, the inclusion command will write the verified inclusion proof to this file")
 	inclusionHash       = flag.Bool("inclusion_hash", false, "If set to true, the inclusion command will take a base64 encoded leaf hash instead of a file name")
+        outputInclusionJson = flag.String("output_inclusion_proof_json", "", "If set, the inclusion command will write all portions of the inclusion proof to this file")
 )
 
 func usage() {
@@ -332,6 +334,33 @@ func (l *logClientTool) inclusionProof(ctx context.Context, args []string) error
 		}
 	}
 
+        if oj:= *outputInclusionJson; len(oj) > 0 {
+		entry, err := client.GetLeaf(ctx, l.Fetcher, idx)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve entry contents: %w", err)
+		}
+
+		pi := proofInfo{
+                        LeafIndex: idx,
+                        Hashes: merkleProof(p),
+                        LeafHash: lh,
+                        LeafValue: entry,
+                        RootHash: cp.Hash,
+                        TreeSize: cp.Size,
+                        Note: l.Tracker.CheckpointNote,
+                }               
+
+                ps, err := json.Marshal(pi)
+                if err != nil {
+                        glog.Warning("Unable to convert proof to JSON")
+                        return err
+                }
+
+                if err := os.WriteFile(oj, ps, 0644); err != nil {
+			glog.Warningf("Failed to write JSON inclusion proof to %q: %v", oj, err)
+                }
+        }
+
 	glog.Infof("Inclusion verified under checkpoint:\n%s", cp.Marshal())
 	return nil
 }
@@ -501,6 +530,17 @@ func distributors() ([]client.Fetcher, error) {
 
 // merkleProof represents Merkle proofs.
 type merkleProof [][]byte
+
+// proofInfo represents a proof and the associated information needed to verify it.
+type proofInfo struct {
+        LeafIndex uint64
+        Hashes merkleProof
+        LeafHash []byte
+        LeafValue []byte
+        RootHash []byte
+        TreeSize uint64
+        Note *note.Note
+}
 
 // Marshal returns a simple string-based representation of the proof.
 func (p merkleProof) Marshal() string {


### PR DESCRIPTION
This change adds an option to the trillian serverless client command for outputting the proof in JSON. This change was rejected from upstream, so we'll need to maintain this separtely.