### PR TITLE
Implement signing using DSM in log transparency tools. HRST-27.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -exu
+
+set -o pipefail
+
+repo_root=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+
+cd "$repo_root"
+
+# Try to find the toolchain directory automatically if it's not specified.
+if [ -z "$TOOLCHAIN_DIR" ] ; then
+    if ! [ -d "$repo_root"/../toolchain ] ; then
+        echo "Unable to find toolchain in $repo_root/toolchain."
+        echo "You may need to check out toolchain or set TOOLCHAIN_DIR to the toolchain location"
+        exit 1
+    fi
+    TOOLCHAIN_DIR="$repo_root/../toolchain"
+fi
+
+source "$TOOLCHAIN_DIR/shell/malbork_env"
+
+cd "$repo_root/serverless/cmd"
+
+for i in client generate_keys integrate sequence ; do
+    pushd $i
+    rm -f $i
+    go build .
+    popd
+done

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	cloud.google.com/go/profiler v0.3.0 // indirect
 	github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/fortanix/sdkms-client-go v0.2.2 // indirect
 	github.com/go-errors/errors v1.0.2 // indirect
 	github.com/go-interpreter/wagon v0.6.0 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
@@ -55,6 +56,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fortanix/sdkms-client-go v0.2.2 h1:dJy3wFPxCnA3hC6Qi8uKSRnrBMp86sYFKn2vwfnhVf4=
+github.com/fortanix/sdkms-client-go v0.2.2/go.mod h1:7df+XH9h8S/MDmF64sHKmDCBmrYqIi/8Ix72PVnRqfQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.0.2 h1:xMxH9j2fNg/L4hLn/4y3M0IUsn0M6Wbu/Uh9QlOfBh4=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
@@ -249,6 +251,9 @@ github.com/miekg/dns v1.1.50/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7Xn
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/perlin-network/life v0.0.0-20191203030451-05c0e0f7eaea h1:okKoivlkNRRLqXraEtatHfEhW+D71QTwkaj+4n4M2Xc=
 github.com/perlin-network/life v0.0.0-20191203030451-05c0e0f7eaea/go.mod h1:3KEU5Dm8MAYWZqity880wOFJ9PhQjyKVZGwAEfc5Q4E=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/proullon/ramsql v0.0.0-20211120092837-c8d0a408b939 h1:mtMU7aT8cTAyNL3O4RyOfe/OOUxwCN525SIbKQoUvw0=

--- a/serverless-test-dsm.sh
+++ b/serverless-test-dsm.sh
@@ -1,0 +1,111 @@
+#!/bin/bash -ex
+
+#
+# Some basic tests of the trillian serverless tooling.
+#
+# I think these aren't covered by the existing tests in their source repository.
+#
+set -o pipefail
+
+if [ -z "$API_KEY" ] ; then
+    echo "Set the environment variable API_KEY to the API key to use for testing"
+    exit 1
+fi
+
+if [ -z "$KEY_ID" ]; then
+    echo "Set the environment variable KEY_ID to the key to use for testing"
+    exit 1
+fi
+
+repo_root=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+
+if [ -z "$SERVERLESS_DIR" ] ; then
+    SERVERLESS_DIR="$repo_root/serverless/cmd"
+fi
+
+set -u
+
+function usage {
+    echo "Usage: serverless-test.sh [--keep-temp-dir]"
+    exit 1
+}
+
+keep_temp_dir=0
+
+while [ "$#" -gt 0 ] ; do
+    arg=$1
+    if [ "$arg" = "--keep-temp-dir" ] ; then
+        keep_temp_dir=1
+        shift
+        continue
+    fi
+    usage
+done
+
+set -x
+
+#
+# serverless command paths
+#
+client="$SERVERLESS_DIR/client/client"
+generate_keys="$SERVERLESS_DIR/generate_keys/generate_keys"
+integrate="$SERVERLESS_DIR/integrate/integrate"
+sequence="$SERVERLESS_DIR/sequence/sequence"
+
+tmpdir=`mktemp -d transparency.XXXXXXXX --tmpdir=`
+pushd "$tmpdir"
+
+storage_dir="--storage_dir=$tmpdir/log"
+keyname="--key_name=log-test-key"
+origin="--origin=mylog"
+
+function cleanup {
+    popd
+    if [ "$keep_temp_dir" = "0" ]; then
+        rm -r "$tmpdir"
+    fi
+}
+
+trap cleanup EXIT
+
+# For the DSM test, we don't need to generate keys, as they're stored in DSM.
+#"$generate_keys" "$keyname" --out_pub=public --out_priv=private
+
+"$integrate" --initialise --logtostderr "$storage_dir" --public_key_out=public --dsm_key_id=$KEY_ID --dsm_api_key=$API_KEY "$origin"
+
+public_material=$(cat public)
+
+mkdir entries
+
+for i in {1..64} ; do
+    echo "This is entry $i" > "entries/$i"
+done
+
+# Sequence the entries. Use two different methods for passing the keys (command line and
+# environment variable)
+for i in {1..32} ; do
+    "$sequence" "$storage_dir" --public_key=public --entries "entries/$i" --logtostderr "$origin"
+    "$integrate" "$storage_dir" --public_key=public --dsm_key_id=$KEY_ID --dsm_api_key=$API_KEY --logtostderr "$origin"
+done
+
+for i in {33..64} ; do
+    SERVERLESS_LOG_PUBLIC_KEY="$public_material" "$sequence" "$storage_dir" --entries "entries/$i" --logtostderr "$origin"
+    "$integrate" "$storage_dir" --dsm_key_id=$KEY_ID --dsm_api_key=$API_KEY --logtostderr "$origin"
+done
+
+# Client inclusion test.
+
+# TODO: Test JSON output format when that code merges.
+# TODO: Test lookup by merkle hash instead of entry contents.
+
+for i in {1..32} ; do
+    "$client" --log_public_key=public --logtostderr --log_url=file://"$tmpdir"/log --cache_dir="" "$origin" --output_inclusion_proof=proof.$i inclusion "entries/$i"
+done
+
+# Temporarily disabling since we're testing on the tree without this option
+for i in {33..64} ; do
+    SERVERLESS_LOG_PUBLIC_KEY="$public_material" "$client" --logtostderr --log_url=file://"$tmpdir"/log --cache_dir="" "$origin" --output_inclusion_proof_json=proof.$i.json inclusion "entries/$i"
+done
+
+
+echo "Test passed"

--- a/serverless-test.sh
+++ b/serverless-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash -ex
+
+#
+# Some basic tests of the trillian serverless tooling.
+#
+# I think these aren't covered by the existing tests in their source repository.
+#
+set -o pipefail
+
+repo_root=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+
+SERVERLESS_DIR="$repo_root/serverless/cmd"
+
+set -u
+
+function usage {
+    echo "Usage: serverless-test.sh [--keep-temp-dir]"
+    exit 1
+}
+
+keep_temp_dir=0
+
+while [ "$#" -gt 0 ] ; do
+    arg=$1
+    if [ "$arg" = "--keep-temp-dir" ] ; then
+        keep_temp_dir=1
+        shift
+        continue
+    fi
+    usage
+done
+
+set -x
+
+#
+# serverless command paths
+#
+client="$SERVERLESS_DIR/client/client"
+generate_keys="$SERVERLESS_DIR/generate_keys/generate_keys"
+integrate="$SERVERLESS_DIR/integrate/integrate"
+sequence="$SERVERLESS_DIR/sequence/sequence"
+
+tmpdir=`mktemp -d transparency.XXXXXXXX --tmpdir=`
+pushd "$tmpdir"
+
+storage_dir="--storage_dir=$tmpdir/log"
+keyname="--key_name=mykey"
+origin="--origin=mylog"
+
+function cleanup {
+    popd
+    if [ "$keep_temp_dir" = "0" ]; then
+        rm -r "$tmpdir"
+    fi
+}
+
+trap cleanup EXIT
+
+"$generate_keys" "$keyname" --out_pub=public --out_priv=private
+
+public_material=$(cat public)
+private_material=$(cat private)
+
+"$integrate" --initialise --logtostderr "$storage_dir" --public_key=public --private_key=private "$origin"
+
+mkdir entries
+
+for i in {1..64} ; do
+    echo "This is entry $i" > "entries/$i"
+done
+
+# Sequence the entries. Use two different methods for passing the keys (command line and
+# environment variable)
+for i in {1..32} ; do
+    "$sequence" "$storage_dir" --public_key=public --entries "entries/$i" --logtostderr "$origin"
+    "$integrate" "$storage_dir" --public_key=public --private_key=private --logtostderr "$origin"
+done
+
+for i in {33..64} ; do
+    SERVERLESS_LOG_PUBLIC_KEY="$public_material" "$sequence" "$storage_dir" --entries "entries/$i" --logtostderr "$origin"
+    SERVERLESS_LOG_PUBLIC_KEY="$public_material" SERVERLESS_LOG_PRIVATE_KEY="$private_material" "$integrate" "$storage_dir" --logtostderr "$origin"
+done
+
+# Client inclusion test.
+
+# TODO: Test JSON output format when that code merges.
+# TODO: Test lookup by merkle hash instead of entry contents.
+
+for i in {1..32} ; do
+    "$client" --log_public_key=public --logtostderr --log_url=file://"$tmpdir"/log --cache_dir="" "$origin" --output_inclusion_proof=proof.$i inclusion "entries/$i"
+done
+
+# Temporarily disabling since we're testing on the tree without this option
+for i in {33..64} ; do
+    SERVERLESS_LOG_PUBLIC_KEY="$public_material" "$client" --logtostderr --log_url=file://"$tmpdir"/log --cache_dir="" "$origin" --output_inclusion_proof_json=proof.$i.json inclusion "entries/$i"
+    
+    #SERVERLESS_LOG_PUBLIC_KEY="$public_material" $client --logtostderr verify_proof proof.$i.json
+done
+
+
+echo "Test passed"


### PR DESCRIPTION
This change implements Ed25519 signing in DSM for the Trillian serverless tooling. Integrate is the only command that performs signing. Integrate can write the public key to a file so the commands that need to verify signatures can do so without using DSM.

Also included are some scripts for testing the command-line tools.