### PR TITLE
Implement DSM signing with approvals for Trillian tool. HRST-28

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -exu
+#!/bin/bash -ex
 
 set -o pipefail
 
@@ -20,7 +20,7 @@ source "$TOOLCHAIN_DIR/shell/malbork_env"
 
 cd "$repo_root/serverless/cmd"
 
-for i in client generate_keys integrate sequence ; do
+for i in approve client generate_keys integrate sequence ; do
     pushd $i
     rm -f $i
     go build .

--- a/serverless/cmd/approve/main.go
+++ b/serverless/cmd/approve/main.go
@@ -1,0 +1,57 @@
+// Program for approving DSM crypto requests.
+
+package main
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"os"
+
+	"github.com/fortanix/sdkms-client-go/sdkms"
+	"github.com/golang/glog"
+)
+
+var (
+	dsmApiKey   = flag.String("dsm_api_key", "", "API key for accessing smartkey")
+	dsmEndpoint = flag.String("dsm_endpoint", "https://www.smartkey.io", "DSM instance to use when signing with DSM")
+	state       = flag.String("state", "", "State file for the request to approve")
+)
+
+type QuorumSigningState struct {
+	Msg []byte
+	RequestID sdkms.UUID
+}
+
+func main() {
+	flag.Parse()
+
+	data, err := os.ReadFile(*state)
+	if err != nil {
+		glog.Exitf("Unable to read state file: %q", err)
+	}
+	var request QuorumSigningState
+	err = json.Unmarshal(data, &request)
+	if err != nil {
+		glog.Exitf("Unable to deserialize request data: %q", err)
+	}
+
+	if len(*dsmApiKey) == 0 {
+		glog.Exitf("dsm_api_key is required")
+	}
+
+	if len(*dsmEndpoint) == 0 {
+		glog.Exitf("dsm_endpoint is required")
+	}
+
+	client := sdkms.Client{
+		HTTPClient: http.DefaultClient,
+		Auth: sdkms.APIKey(*dsmApiKey),
+		Endpoint: *dsmEndpoint,
+	}
+	body := sdkms.ApproveRequest{}
+	_, err = client.ApproveRequest(context.Background(), request.RequestID, body)
+	if err != nil {
+		glog.Exitf("Error approving request: %q", err)
+	}
+}


### PR DESCRIPTION
My previous change to the Trillian tooling added the ability to sign with DSM. This change extends that capability to sign using keys that require quorum approvals.

The integrate command is the only one that performs signing. It will automatically try to sign without an approval. It will only attempt to sign with an approval if signing without the approval returns an error indicating that an approval is required.

This can be used in two different modes. By default, the integrate command will continue running and will wait util the request is either approved or denied. Alternatively, you can pass the --suspend option with a file name. In this case, if approval is required, some state will be written to the named file. After the signing request is approved, you can resume signing with --resume, and the operation will be completed with the signature produced by DSM.

I've also added a command line tool for approving signing requests. This is intended to be used by the
serverless-test-dsm-approvals.sh test script with an appropriately configured group so the requested signatures for the test can be approved without having someone manually approve them in the UI.