### PR TITLE
Provide an app-specific index for transparency log entries. HRST-70.

### DIFF
--- a/serverless/api/layout/paths.go
+++ b/serverless/api/layout/paths.go
@@ -29,6 +29,8 @@ import (
 const (
 	// CheckpointPath is the location of the file containing the log checkpoint.
 	CheckpointPath = "checkpoint"
+	AppIndexSubdir = "app_index"
+	LeafSubdir = "leaves"
 )
 
 // SeqPath builds the directory path and relative filename for the entry at the given
@@ -65,12 +67,10 @@ func SeqFromPath(root, seqPath string) (uint64, error) {
 	return strconv.ParseUint(b.String(), 16, 64)
 }
 
-// LeafPath builds the directory path and relative filename for the entry data with the
-// given leafhash.
-func LeafPath(root string, leafhash []byte) (string, string) {
+func pathHelper(root string, subdir string, leafhash []byte) (string, string) {
 	frag := []string{
 		root,
-		"leaves",
+		subdir,
 		fmt.Sprintf("%02x", leafhash[0]),
 		fmt.Sprintf("%02x", leafhash[1]),
 		fmt.Sprintf("%02x", leafhash[2]),
@@ -78,6 +78,12 @@ func LeafPath(root string, leafhash []byte) (string, string) {
 	}
 	d := filepath.Join(frag[:5]...)
 	return d, frag[5]
+}
+
+// LeafPath builds the directory path and relative filename for the entry data with the
+// given leafhash.
+func LeafPath(root string, leafhash []byte) (string, string) {
+	return pathHelper(root, LeafSubdir, leafhash)
 }
 
 // TilePath builds the directory path and relative filename for the subtree tile with the
@@ -101,4 +107,10 @@ func TilePath(root string, level, index, partialTileSize uint64) (string, string
 	}
 	d := filepath.Join(frag[:6]...)
 	return d, frag[6]
+}
+
+// AppIndexPath builds the directory path and relative filename for the application-specific
+// index file.
+func AppIndexPath(root string, appIndex []byte) (string, string) {
+	return pathHelper(root, AppIndexSubdir, appIndex)
 }

--- a/serverless/api/layout/paths_test.go
+++ b/serverless/api/layout/paths_test.go
@@ -113,7 +113,9 @@ func TestSeqFromPath(t *testing.T) {
 	}
 }
 
-func TestLeafPath(t *testing.T) {
+// Helper function for testing the path creation functions that operate on hashes.
+func hashPathHelper(t *testing.T, testFunc func(string, []byte) (string, string), subpath string) {
+	t.Helper()
 	for _, test := range []struct {
 		root     string
 		hash     []byte
@@ -123,23 +125,23 @@ func TestLeafPath(t *testing.T) {
 		{
 			root:     "/root/path",
 			hash:     []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77},
-			wantDir:  "/root/path/leaves/11/22/33",
+			wantDir:  fmt.Sprintf("/root/path/%s/11/22/33", subpath),
 			wantFile: "44556677",
 		}, {
 			root:     "/root/path",
 			hash:     []byte{0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd},
-			wantDir:  "/root/path/leaves/88/99/aa",
+			wantDir:  fmt.Sprintf("/root/path/%s/88/99/aa", subpath),
 			wantFile: "bbccdd",
 		}, {
 			root:     "/a/different/root/path",
 			hash:     []byte{0x12, 0x34, 0x56, 0x78, 0x9a},
-			wantDir:  "/a/different/root/path/leaves/12/34/56",
+			wantDir:  fmt.Sprintf("/a/different/root/path/%s/12/34/56", subpath),
 			wantFile: "789a",
 		},
 	} {
 		desc := fmt.Sprintf("root %q hash %x", test.root, test.hash)
 		t.Run(desc, func(t *testing.T) {
-			gotDir, gotFile := LeafPath(test.root, test.hash)
+			gotDir, gotFile := testFunc(test.root, test.hash)
 			if gotDir != test.wantDir {
 				t.Errorf("Got dir %q want %q", gotDir, test.wantDir)
 			}
@@ -148,6 +150,14 @@ func TestLeafPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLeafPath(t *testing.T) {
+	hashPathHelper(t, LeafPath, "leaves")
+}
+
+func TestAppIndexPath(t *testing.T) {
+	hashPathHelper(t, AppIndexPath, "app_index")
 }
 
 func TestTilePath(t *testing.T) {

--- a/serverless/api/state.go
+++ b/serverless/api/state.go
@@ -39,6 +39,18 @@ type Tile struct {
 	Nodes [][]byte
 }
 
+// This structure maps an application-specific identifier to a list of indices of entries matching that list.
+// This is to support efficient lookup of entries by the application-specific identifier. It is possible that
+// multiple log entries all correspond to the same application-specific identifier, so it is necessary to
+// refer to all matching entries so they can be all be retrieved.
+//
+// The value here is the numeric index of the entry in the log. This will need to be converted into a hexadecimal
+// string and then separated into elements to find the actual path to the log entry. This is done by the client
+// program when looking up by index.
+type EntryList struct {
+	Indices []uint64
+}
+
 // MarshalText implements encoding/TextMarshaller and writes out a Tile
 // instance in the following format:
 //


### PR DESCRIPTION
The transparency infrastructure currently only provides efficient lookup for entries if you have either the entire entry, or at least the node hash of the entry (which is not simply the sha256 hash of the entry). What we want instead is the ability to look up entries by a subset of their contents. Specifically in our case, we would like to find the entries with a specific tuple of (mrenclave, mrsigner, isvprodid, isvsvn), without needing to know any of the other entry values.

To allow for this, I've added a mechanism for an app-specific identifier to be associated with an entry when it's added, and the ability to look up entries by their app-specific identifier. It's up to the client adding entries and looking up entries to compute this identifier themselves. I could have made the transparency tooling able to compute these identifiers themselves, but the tooling currently doesn't need to know anything about the contents of the log entries, and I would like to keep it that way.

The index that allows looking up by app-specific identifier is in addition to the normal transparency data structures. 3rd party log monitoring utilities should be able to monitor our logs and simply ignore the additional index. The new index just provides us a mechanism to find particular entries based on a different lookup key, and doesn't affect the security of the append-only logs in any way.